### PR TITLE
JSON::PP backend of JSON requires to force scalar context

### DIFF
--- a/lib/Net/RDAP.pm
+++ b/lib/Net/RDAP.pm
@@ -414,7 +414,7 @@ sub _get {
 
     } else {
         $response = $self->ua->mirror($url, $file, $ttl);
-        eval { $data = decode_json(read_file($file)) };
+        eval { $data = decode_json(scalar(read_file($file))) };
 
     }
 


### PR DESCRIPTION
Hello

Using default caching mode, when passing directly `read_file` to `decode_json` we get some `Error: 500 (Error parsing response body)`.
It is only present with backend JSON::PP of JSON module (and JSON::PP is not the default backend).

Seems like some sort of list context is confusing `decode_json`.

I think you can force with `scalar` (this proposed change) or slurp outside of `decode_json`.

